### PR TITLE
Compile model before training

### DIFF
--- a/train.py
+++ b/train.py
@@ -146,6 +146,10 @@ def main(args):
         ).to(device)
     else:
         raise ValueError
+    try:
+        model = torch.compile(model)
+    except Exception as e:
+        print(f"torch.compile failed: {e}. Running model without compilation.")
 
     wandb.init(
         project="train-ego-path-detection",


### PR DESCRIPTION
PyTorch 2.0 released [`torch.compile`](https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html), which can significantly speedup training and inference with minimal overhead. The code base did not yet make use of `torch.compile`, so I added it. The speed-up that can be expected from `torch.compile` is platform dependent, but on my RTX 4090 it reduced training time from 537 minutes to 442 minutes for the model I tested the comparison on (efficientnet-b3 with regression, default training settings, single run), a speed-up of about 17.7 percent. An even larger speed-up is expected on datacenter GPUs like the H100, A100, or V100. 

![image](https://github.com/user-attachments/assets/210f9c3e-f0a4-4153-b489-08fbcb3daa95)

`torch.compile` is not available on older PyTorch versions (<2.0) or certain GPU architectures (e.g., older CUDA devices). If unavailable, the model runs as before, with a warning message explaining why compilation was skipped. The model will then not be compiled and execution continues identically to the way it did before my changes were made.

TL;DR: Added `torch.compile` for a significant training speed-up with minimal overhead. Wrapped in a try-except for compatibility. No behavior change if unsupported. 