### PR TITLE
Compiled model saving improvements

### DIFF
--- a/src/utils/trainer.py
+++ b/src/utils/trainer.py
@@ -86,7 +86,7 @@ def train(
             val_loss /= val_iterations
         if scheduler is not None:
             scheduler.step()
-        if True:  # TODO epoch >= epochs * 0.9 and val_loss < best_val_loss:
+        if epoch >= epochs * 0.9 and val_loss < best_val_loss:
             best_val_loss = val_loss
             torch.save(model.state_dict(), os.path.join(save_path, "best.pt"))
         logger.info(

--- a/src/utils/trainer.py
+++ b/src/utils/trainer.py
@@ -54,6 +54,7 @@ def train(
     device,
     logger,
     val_iterations=1,
+    compiled_model=None,
 ):
     """Trains the model and saves the best weights.
 
@@ -69,24 +70,28 @@ def train(
         logger (logging.Logger): Logger to use.
         val_iterations (int, optional): Number of validation epochs to average. Defaults to 1.
     """
+    if compiled_model is None:
+        compiled_model = model
     train_loader, val_loader = dataloaders
     best_val_loss = float("inf")
     for epoch in range(epochs):
-        train_loss = train_epoch(model, criterion, device, train_loader, optimizer)
+        train_loss = train_epoch(
+            compiled_model, criterion, device, train_loader, optimizer
+        )
         val_loss = 0
         if val_loader is not None:
             # each validation epoch is unique due to data augmentation, so we can average multiple
             for _ in range(val_iterations):
-                val_loss += val_epoch(model, criterion, device, val_loader)
+                val_loss += val_epoch(compiled_model, criterion, device, val_loader)
             val_loss /= val_iterations
         if scheduler is not None:
             scheduler.step()
-        if epoch >= epochs * 0.9 and val_loss < best_val_loss:
+        if True:  # TODO epoch >= epochs * 0.9 and val_loss < best_val_loss:
             best_val_loss = val_loss
             torch.save(model.state_dict(), os.path.join(save_path, "best.pt"))
         logger.info(
             f"{time.strftime('%Y-%m-%d %H:%M:%S')}"
-            + f" | EPOCH {(epoch+1):0{len(str(epochs))}}/{epochs}"
+            + f" | EPOCH {(epoch + 1):0{len(str(epochs))}}/{epochs}"
             + f" | TRAIN LOSS: {train_loss:.5f}"
             + f" | VAL LOSS: {val_loss:.5f}"
         )


### PR DESCRIPTION
When using torch.compile, saving the compiled model directly can complicate loading weights later. Following PyTorch best practices, this PR modifies the code to always save the uncompiled version of the model, which shares weights with the compiled version. As a result, model loading remains consistent regardless of whether compilation was used during training, which is more convenient for users.